### PR TITLE
feat: add findById endpoint for IndexInfo

### DIFF
--- a/src/main/java/com/findex/controller/IndexInfoController.java
+++ b/src/main/java/com/findex/controller/IndexInfoController.java
@@ -6,6 +6,8 @@ import com.findex.service.IndexInfoService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,5 +25,11 @@ public class IndexInfoController {
     @ResponseStatus(HttpStatus.CREATED)
     public IndexInfoDto create(@RequestBody @Valid IndexInfoCreateRequest req) {
         return indexInfoService.create(req);
+    }
+
+    @GetMapping("/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public IndexInfoDto findById(@PathVariable Long id) {
+        return indexInfoService.findById(id);
     }
 }

--- a/src/main/java/com/findex/repository/IndexInfoRepository.java
+++ b/src/main/java/com/findex/repository/IndexInfoRepository.java
@@ -1,7 +1,15 @@
 package com.findex.repository;
 
 import com.findex.entity.IndexInfo;
+import com.findex.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IndexInfoRepository extends JpaRepository<IndexInfo, Long> {
+
+    default IndexInfo getOrThrow(Long id) {
+        return findById(id).orElseThrow(() ->
+            new NotFoundException(
+                "IndexInfo with id %s not found".formatted(id))
+        );
+    }
 }

--- a/src/main/java/com/findex/service/IndexInfoService.java
+++ b/src/main/java/com/findex/service/IndexInfoService.java
@@ -35,4 +35,8 @@ public class IndexInfoService {
 
         return indexInfoMapper.toDto(indexInfo);
     }
+
+    public IndexInfoDto findById(Long id) {
+        return indexInfoMapper.toDto(indexInfoRepository.getOrThrow(id));
+    }
 }


### PR DESCRIPTION
지수 정보 조회 기능 작성

- 'IndexInfoService'와 'IndexInfoController'에 'findById' 메서드를 추가했습니다.
- 사용자 정의 'NotFoundException'을 사용하여 'IndexInfoRepository'에 'getOrThrow' 기본 메서드를 도입했습니다.
