### PR TITLE
refactor: 자동 연동 설정 객체 생성을 지수 정보 엔티티에서 생성하도록 변경

### DIFF
--- a/src/main/java/com/findex/entity/IndexInfo.java
+++ b/src/main/java/com/findex/entity/IndexInfo.java
@@ -2,20 +2,20 @@ package com.findex.entity;
 
 import com.findex.entity.base.BaseEntity;
 import com.findex.enums.IndexSourceType;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Entity
 @Table(name = "index_info")
 public class IndexInfo extends BaseEntity {
@@ -39,4 +39,30 @@ public class IndexInfo extends BaseEntity {
 
     @Setter
     private boolean favorite;
+
+    @OneToOne(
+        mappedBy = "indexInfo",
+        cascade = CascadeType.ALL,
+        orphanRemoval = true
+    )
+    private AutoSyncConfig autoSyncConfig;
+
+    public IndexInfo(
+        String indexClassification,
+        String indexName,
+        Integer employedItemsCount,
+        LocalDate basePointInTime,
+        Integer baseIndex,
+        IndexSourceType sourceType,
+        boolean favorite
+    ) {
+        this.indexClassification = indexClassification;
+        this.indexName = indexName;
+        this.employedItemsCount = employedItemsCount;
+        this.basePointInTime = basePointInTime;
+        this.baseIndex = baseIndex;
+        this.sourceType = sourceType;
+        this.favorite = favorite;
+        this.autoSyncConfig = new AutoSyncConfig(false, this);
+    }
 }

--- a/src/main/java/com/findex/service/AutoSyncConfigService.java
+++ b/src/main/java/com/findex/service/AutoSyncConfigService.java
@@ -3,7 +3,6 @@ package com.findex.service;
 import com.findex.dto.autoSyncConfig.AutoSyncConfigDto;
 import com.findex.dto.autoSyncConfig.AutoSyncConfigUpdateRequest;
 import com.findex.entity.AutoSyncConfig;
-import com.findex.entity.IndexInfo;
 import com.findex.exception.NotFoundException;
 import com.findex.mapper.AutoSyncConfigMapper;
 import com.findex.repository.AutoSyncConfigRepository;
@@ -16,16 +15,6 @@ import org.springframework.stereotype.Service;
 public class AutoSyncConfigService {
     private final AutoSyncConfigRepository autoSyncConfigRepository;
     private final AutoSyncConfigMapper autoSyncConfigMapper;
-
-    public AutoSyncConfigDto create(IndexInfo indexInfo) {
-        if (autoSyncConfigRepository.existsByIndexInfoId(indexInfo.getId())) {
-            throw new IllegalStateException("already exists indexInfo in AutoSyncConfig");
-        }
-
-        AutoSyncConfig autoSyncConfig = new AutoSyncConfig(false, indexInfo);
-
-        return autoSyncConfigMapper.toDto(autoSyncConfigRepository.saveAndFlush(autoSyncConfig));
-    }
 
     @Transactional
     public AutoSyncConfigDto update(Long id, AutoSyncConfigUpdateRequest request) {

--- a/src/main/java/com/findex/service/IndexInfoService.java
+++ b/src/main/java/com/findex/service/IndexInfoService.java
@@ -12,18 +12,15 @@ import com.findex.mapper.IndexInfoMapper;
 import com.findex.repository.indexinfo.IndexInfoRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class IndexInfoService {
 
     private final IndexInfoRepository indexInfoRepository;
-    private final AutoSyncConfigService autoSyncConfigService;
     private final IndexInfoMapper indexInfoMapper;
 
     public CursorPageResponse findAll(IndexInfoQuery query) {
@@ -43,7 +40,6 @@ public class IndexInfoService {
                         req.favorite() != null && req.favorite()
                 )
         );
-        autoSyncConfigService.create(indexInfo);
         return indexInfoMapper.toDto(indexInfo);
     }
 


### PR DESCRIPTION
AutoSyncConfig create 메서드를 제거하고 지수 정보의 생명주기로 자동 생성/제거되도록 변경하였습니다.

```java
    public IndexInfo(
        String indexClassification,
        String indexName,
        Integer employedItemsCount,
        LocalDate basePointInTime,
        Integer baseIndex,
        IndexSourceType sourceType,
        boolean favorite
    ) {
        this.indexClassification = indexClassification;
        this.indexName = indexName;
        this.employedItemsCount = employedItemsCount;
        this.basePointInTime = basePointInTime;
        this.baseIndex = baseIndex;
        this.sourceType = sourceType;
        this.favorite = favorite;
        this.autoSyncConfig = new AutoSyncConfig(false, this);
    }
```